### PR TITLE
Reuse proto writing in datastore and pass configuration for in-place updates

### DIFF
--- a/pkg/common/data_store.go
+++ b/pkg/common/data_store.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flyteorg/flyteadmin/pkg/errors"
 	"github.com/flyteorg/flyteadmin/pkg/manager/impl/shared"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	//"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flytestdlib/storage"
 	"github.com/golang/protobuf/proto"
 	errrs "github.com/pkg/errors"
@@ -55,39 +54,3 @@ func isRetryableError(err error) bool {
 	}
 	return false
 }
-
-/*func OffloadWorkflowClosure(ctx context.Context, storageClient *storage.DataStore, flyteWf *v1alpha1.FlyteWorkflow, workflowClosure *core.CompiledWorkflowClosure, executionID v1alpha1.ExecutionID) error {
-	reference, err := store(ctx, storageClient, workflowClosure, nestedKeys(executionID, shared.WorkflowClosure)...)
-	if err != nil {
-		return err
-	}
-
-	flyteWf.WorkflowClosureDataReference = reference
-	flyteWf.WorkflowSpec = nil
-	flyteWf.SubWorkflows = nil
-	flyteWf.Tasks = nil
-	return nil
-}
-
-func nestedKeys(execID v1alpha1.ExecutionID, filename string) []string {
-	return []string{shared.Metadata, execID.GetProject(), execID.Domain, execID.Name, filename}
-}
-
-func store(ctx context.Context, storageClient *storage.DataStore, workflowClosure *core.CompiledWorkflowClosure, nestedKeys ...string) (storage.DataReference, error) {
-
-	base := storageClient.GetBaseContainerFQN(ctx)
-	remoteClosureDataRef, err := storageClient.ConstructReference(ctx, base, nestedKeys...)
-	if err != nil {
-		return "", err
-	}
-
-	if err != nil {
-		return "", err
-	}
-	err = storageClient.WriteProtobuf(ctx, remoteClosureDataRef, storage.Options{}, workflowClosure)
-	if err != nil {
-		return "", err
-	}
-
-	return remoteClosureDataRef, nil
-}*/

--- a/pkg/common/data_store_test.go
+++ b/pkg/common/data_store_test.go
@@ -67,7 +67,7 @@ func TestOffloadLiteralMap_StorageFailure(t *testing.T) {
 	assert.Equal(t, err.(errors.FlyteAdminError).Code(), codes.Internal)
 }
 
-func TestOffloadLiteralMap_RetryOn409(t *testing.T) {
+func TestOffloadProto_RetryOn409(t *testing.T) {
 	mockStorage := commonMocks.GetMockStorageClient()
 	retries := 0
 	mockStorage.ComposedProtobufStore.(*commonMocks.TestDataStore).WriteProtobufCb = func(ctx context.Context, reference storage.DataReference, opts storage.Options, msg proto.Message) error {
@@ -76,7 +76,7 @@ func TestOffloadLiteralMap_RetryOn409(t *testing.T) {
 		return errs.Wrapf(&googleapi.Error{Code: 409}, "Failed to write data [%vb] to path [%v].", 10, "size")
 	}
 	expectedRetries := 2
-	_, err := OffloadLiteralMapWithRetryDelayAndAttempts(context.TODO(), mockStorage, literalMap, time.Millisecond, expectedRetries, "nested", "key")
+	_, err := OffloadProtoWithRetryDelayAndAttempts(context.TODO(), mockStorage, literalMap, time.Millisecond, expectedRetries, "nested", "key")
 	assert.EqualValues(t, retries, expectedRetries+1)
 	assert.Equal(t, err.(errors.FlyteAdminError).Code(), codes.Internal)
 }

--- a/pkg/rpc/adminservice/base.go
+++ b/pkg/rpc/adminservice/base.go
@@ -92,7 +92,7 @@ func NewAdminServer(ctx context.Context, pluginRegistry *plugins.Registry, confi
 		repo)
 	workflowBuilder := workflowengineImpl.NewFlyteWorkflowBuilder(
 		adminScope.NewSubScope("builder").NewSubScope("flytepropeller"))
-	workflowExecutor := workflowengineImpl.NewK8sWorkflowExecutor(execCluster, workflowBuilder, dataStorageClient, applicationConfiguration.OffloadWorkflowClosureToStorage)
+	workflowExecutor := workflowengineImpl.NewK8sWorkflowExecutor(configuration, execCluster, workflowBuilder, dataStorageClient)
 	logger.Info(ctx, "Successfully created a workflow executor engine")
 	pluginRegistry.RegisterDefault(plugins.PluginIDWorkflowExecutor, workflowExecutor)
 

--- a/pkg/workflowengine/impl/k8s_executor.go
+++ b/pkg/workflowengine/impl/k8s_executor.go
@@ -49,8 +49,8 @@ func (e K8sWorkflowExecutor) Execute(ctx context.Context, data interfaces.Execut
 
 	if e.config.ApplicationConfiguration().GetTopLevelConfig().OffloadWorkflowClosureToStorage {
 		// if offloading workflow closure is enabled we write the proto using the storage client
-		// and remove the fields from the FlyteWorkflow CRD. The are read from the storage client
-		// and repopulated during execution to reduce the CRD size.
+		// and remove the fields from the FlyteWorkflow CRD. They are read from the storage client
+		// and temporarily repopulated during execution to reduce the CRD size.
 		execID := flyteWf.ExecutionID
 		reference, err := common.OffloadProto(ctx, e.storageClient, data.WorkflowClosure,
 			execID.GetProject(), execID.Domain, execID.Name, shared.WorkflowClosure)

--- a/pkg/workflowengine/impl/k8s_executor_test.go
+++ b/pkg/workflowengine/impl/k8s_executor_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/flyteorg/flyteadmin/pkg/executioncluster"
 	execClusterIfaces "github.com/flyteorg/flyteadmin/pkg/executioncluster/interfaces"
 	clusterMock "github.com/flyteorg/flyteadmin/pkg/executioncluster/mocks"
+	runtimeInterfaces "github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
+	runtimeMocks "github.com/flyteorg/flyteadmin/pkg/runtime/mocks"
 	"github.com/flyteorg/flyteadmin/pkg/workflowengine/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/workflowengine/mocks"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -132,6 +134,13 @@ func TestExecute(t *testing.T) {
 		assert.Equal(t, namespace, ns)
 		return &fakeFlyteWorkflow
 	}
+
+	mockApplicationConfig := runtimeMocks.MockApplicationProvider{}
+	mockApplicationConfig.SetTopLevelConfig(runtimeInterfaces.ApplicationConfig{
+		OffloadWorkflowClosureToStorage: false,
+	})
+	mockRuntime := runtimeMocks.NewMockConfigurationProvider(&mockApplicationConfig, nil, nil, nil, nil, nil)
+
 	mockBuilder := mocks.FlyteWorkflowBuilder{}
 	workflowClosure := core.CompiledWorkflowClosure{
 		Primary: &core.CompiledWorkflow{
@@ -153,6 +162,7 @@ func TestExecute(t *testing.T) {
 		return proto.Equal(executionID, execID)
 	}), namespace).Return(flyteWf, nil)
 	executor := K8sWorkflowExecutor{
+		config:           mockRuntime,
 		workflowBuilder:  &mockBuilder,
 		executionCluster: getFakeExecutionCluster(),
 	}
@@ -188,9 +198,17 @@ func TestExecute_AlreadyExists(t *testing.T) {
 		assert.Equal(t, namespace, ns)
 		return &fakeFlyteWorkflow
 	}
+
+	mockApplicationConfig := runtimeMocks.MockApplicationProvider{}
+	mockApplicationConfig.SetTopLevelConfig(runtimeInterfaces.ApplicationConfig{
+		OffloadWorkflowClosureToStorage: false,
+	})
+	mockRuntime := runtimeMocks.NewMockConfigurationProvider(&mockApplicationConfig, nil, nil, nil, nil, nil)
+
 	mockBuilder := mocks.FlyteWorkflowBuilder{}
 	mockBuilder.OnBuildMatch(mock.Anything, mock.Anything, mock.Anything, namespace).Return(flyteWf, nil)
 	executor := K8sWorkflowExecutor{
+		config:           mockRuntime,
 		workflowBuilder:  &mockBuilder,
 		executionCluster: getFakeExecutionCluster(),
 	}
@@ -224,9 +242,17 @@ func TestExecute_MiscError(t *testing.T) {
 		assert.Equal(t, namespace, ns)
 		return &fakeFlyteWorkflow
 	}
+
+	mockApplicationConfig := runtimeMocks.MockApplicationProvider{}
+	mockApplicationConfig.SetTopLevelConfig(runtimeInterfaces.ApplicationConfig{
+		OffloadWorkflowClosureToStorage: false,
+	})
+	mockRuntime := runtimeMocks.NewMockConfigurationProvider(&mockApplicationConfig, nil, nil, nil, nil, nil)
+
 	mockBuilder := mocks.FlyteWorkflowBuilder{}
 	mockBuilder.OnBuildMatch(mock.Anything, mock.Anything, mock.Anything, namespace).Return(flyteWf, nil)
 	executor := K8sWorkflowExecutor{
+		config:           mockRuntime,
 		workflowBuilder:  &mockBuilder,
 		executionCluster: getFakeExecutionCluster(),
 	}


### PR DESCRIPTION
Cleaned up two things:
(1) We can probably just reuse the current function in the data_store.go file. I renamed it, and called it directly. It's previous use is to write execution input data to the metastore, but it just writes a protobuf. Also, it contains some internal retry logic that is probably useful to have.
(2) Passing the configuration to the k8s executor rather than the boolean. This is beneficial because by retrieving the value from the configuration we can update the k8s configmap and it is automatically updated in flyteadmin without having to restart the service.